### PR TITLE
Fix expo-doctor error and Expo SDK 52 prebuild support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## `[3.7.1]` - 2024-10-24
+
+### Changes
+
+- Added app.plugin.js to fix expo doctor error & Expo SDK 52 prebuild support
+
 ## `[3.7.0]` - 2024-07-05
 
 ### Changes

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/plugin/withNotifee.js");

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "author": "kevpug",
   "contributors": [
     "Kevin Pugliese",
-    "Rodrigo Klosowski"
+    "Rodrigo Klosowski",
+    "Ronald Kasendwa"
   ],
   "license": "MIT",
   "homepage": "https://github.com/evennit/notifee-expo-plugin",


### PR DESCRIPTION
The new `expo-doctor` plugin requires an `app.plugin.js` file in every plugin. It's the plugin's entry point.

This PR just duplicates the `index.js` file at the root to create the `app.plugin.js` file that `expo-doctor` looks for. This ensures there's no distraction to future plans should this package ever need to do more than just serve as a plugin